### PR TITLE
Using new compressed nvd files

### DIFF
--- a/utils/nvd_sync.sh
+++ b/utils/nvd_sync.sh
@@ -44,7 +44,8 @@ i=2002
 
 year=`date +"%Y"`
 while [ $i -le $year ]; do
-      wget  http://nvd.nist.gov/download/nvdcve-$i.xml
+      wget  https://nvd.nist.gov/download/nvdcve-$i.xml.gz
+      gunzip nvdcve-$i.xml.gz
       i=`expr $i + 1`
 done
 cd ..


### PR DESCRIPTION
Since October 16 2015 NVD only allows downloading compressed files for the xmls.
using those files now.

see: 
https://nvd.nist.gov/download.cfm#CVE_FEED
